### PR TITLE
Check for existing CUDA context before new context creation

### DIFF
--- a/libomptarget/plugins/cuda/src/rtl.cpp
+++ b/libomptarget/plugins/cuda/src/rtl.cpp
@@ -252,9 +252,13 @@ int32_t __tgt_rtl_init_device(int32_t device_id) {
     return OFFLOAD_FAIL;
   }
 
-  // Create the context and save it to use whenever this device is selected.
-  err = cuCtxCreate(&DeviceInfo.Contexts[device_id], CU_CTX_SCHED_BLOCKING_SYNC,
+  err = cuCtxGetCurrent(&DeviceInfo.Contexts[device_id]);  
+  if(DeviceInfo.Contexts[device_id] == NULL){
+    // Create the context and save it to use whenever this device is selected.
+    err = cuCtxCreate(&DeviceInfo.Contexts[device_id], CU_CTX_SCHED_BLOCKING_SYNC,
                     cuDevice);
+  }
+
   if (err != CUDA_SUCCESS) {
     DP("Error when creating a CUDA context\n");
     CUDA_ERR_STRING(err);


### PR DESCRIPTION
This commit checks for an existing CUDA context (using cuCtxGetCurrent), before creating a new context. If an existing context exists, no new context is created. This change ensures that all allocations made in the program interacting with the openmp offload library are visible in the device context; especially important for CUDA managed allocations (using cudaMallocManaged).

For the existing version, if a context exists, the cuCtxCreate call fails, and hence all further allocations crash.